### PR TITLE
[#109][bugfix] Recurrence changes fix for existing events

### DIFF
--- a/src/routes/events.js
+++ b/src/routes/events.js
@@ -72,8 +72,8 @@ router.route('/update').post(async (req, res) => {
             if (req.body.endTime) {
                 event.endTime = new Date(req.body.endTime);
             }
-            if (req.body.reccurence) {
-                event.reccurence = req.body.reccurence;
+            if (req.body.recurrence) {
+                event.recurrence = req.body.recurrence;
             }
             if (req.body.color) {
                 event.color = req.body.color;


### PR DESCRIPTION
This PR fixes #109.

Description: This issue concerns editing an existing event. A change in recurrence type is not updated correctly.

Cause: The update event route does not implement a previous change to the recurrence parameter name, consequently not updating the parameter correctly.

Solution: Modify the update event route to use the correct parameter name.

Resolved: Resolved.