### PR TITLE
[PR#122][#107][Bugfix] Student course list update bug

### DIFF
--- a/src/repository/eventRepository.js
+++ b/src/repository/eventRepository.js
@@ -168,16 +168,17 @@ module.exports = class EventRepository {
 
     static async #updateCourseList(event){
         if (event.type === 'course' || event.type === 'study' || event.type === 'exam') {
-            let courses = await EventRepository.findByCourse(event.username, event.subject, event.catalog);
-            if (courses.length === 0) {
-                let student = await StudentRepository.findOneByUsername(event.username);
-                let studentCourses = student.courses;
-                let index = studentCourses.findIndex(function (course) {
-                    return (course.subject === event.subject && course.catalog === event.catalog);
-                });
-                studentCourses.splice(index, 1);
-                await StudentRepository.updateCourses(event.username, studentCourses);
-            }
+            EventRepository.findByCourse(event.username, event.subject, event.catalog).then(async (courses) => {
+                if (courses.length === 0) {
+                    let student = await StudentRepository.findOneByUsername(event.username);
+                    let studentCourses = student.courses;
+                    let index = studentCourses.findIndex(function (course) {
+                        return (course.subject === event.subject && course.catalog === event.catalog);
+                    });
+                    studentCourses.splice(index, 1);
+                    await StudentRepository.updateCourses(event.username, studentCourses);
+                }
+            })
         }
     }
 

--- a/src/repository/eventRepository.js
+++ b/src/repository/eventRepository.js
@@ -205,7 +205,7 @@ module.exports = class EventRepository {
     static updateOne(event) {
         return new Promise((resolve, reject) => {
             EventValidator.validateCreateData(event).then(() => {
-                this.findOne(event.eventID).then((originalEvent) => {
+                this.findOneByID(event._id).then((originalEvent) => {
                     event.save(async (err, updatedEvent) => {
                         if (err) {
                             reject(err);

--- a/src/routes/events.js
+++ b/src/routes/events.js
@@ -1,8 +1,5 @@
 const router = require('express').Router();
-const EventRepository = require('../repository/eventRepository')
-const StudentRepository = require('../repository/studentRepository');
-const OpenDataCourseRepository = require("../repository/conUOpenDataCourseRepository");
-const _ = require('lodash');
+const EventRepository = require('../repository/eventRepository');
 const TokenVerify = require('../repository/tokenRepository').verifyJWTAuth;
 
 
@@ -56,7 +53,7 @@ router.route('/events-monthly/:username').get(TokenVerify, (req, res) => {
  */
 router.route('/:eventID').delete(TokenVerify, (req, res) => {
     EventRepository.deleteOne(req.params.eventID)
-        .then(async () => {
+        .then(() => {
             res.status(200).json(`Event deleted`);
         })
         .catch(err => res.status(400).json('Error: ' + err));
@@ -118,26 +115,7 @@ router.route('/update').post(TokenVerify, (req, res) => {
  */
 router.route('/add').post(TokenVerify, async (req, res) => {
     EventRepository.create(req.body)
-        .then(async (event) => {
-            // Add course to student if doesn't already exist in student's courses list.
-            if (event.type === 'course') {
-                let student = await StudentRepository.findOneByUsername(event.username)
-                let courses = student.courses;
-                let conUCourse = await OpenDataCourseRepository.findByCourseCodeAndNumber(event.subject, event.catalog)
-                let course = {
-                    'title': conUCourse.title,
-                    'subject': event.subject,
-                    'catalog': event.catalog,
-                    'classUnit': conUCourse.classUnit,
-                    'studyHours': (parseFloat(conUCourse.classUnit) * 1.5).toString()
-                }
-                if (!(courses.some(item => _.isEqual(item, course)))) {
-                    courses.push(course);
-                    await StudentRepository.updateCourses(event.username, courses);
-                }
-
-            }
-
+        .then((event) => {
             res.status(200).json(event)
         })
         .catch(err => { res.status(400).json(err); });

--- a/src/routes/events.js
+++ b/src/routes/events.js
@@ -56,19 +56,7 @@ router.route('/events-monthly/:username').get(TokenVerify, (req, res) => {
  */
 router.route('/:eventID').delete(TokenVerify, (req, res) => {
     EventRepository.deleteOne(req.params.eventID)
-        .then(async (event) => {
-            if (event.type === 'course') {
-                let courses = await EventRepository.findByCourse(event.username, event.subject, event.catalog);
-                if (courses.length === 0) {
-                    let student = await StudentRepository.findOneByUsername(event.username);
-                    let studentCourses = student.courses;
-                    let index = studentCourses.findIndex(function (course) {
-                        return (course.subject === event.subject && course.catalog === event.catalog);
-                    });
-                    studentCourses.splice(index, 1);
-                    await StudentRepository.updateCourses(event.username, studentCourses);
-                }
-            }
+        .then(async () => {
             res.status(200).json(`Event deleted`);
         })
         .catch(err => res.status(400).json('Error: ' + err));


### PR DESCRIPTION
Description: This issue concerns the deletion of a study event for a specific course:
- after deleting all course type events for that course
- after modifying the last remaining course type event for that course to a study type event for that specific course or for any other course
In the above cases, there are no longer any course or study type events for the specified course, in which case it should no longer show up under the `Progress Report` tab for study hour estimations.

Cause: The suspected cause is that the check for courses associated with a student is not done on event updates.

Solution:
- modified delete event methods to also check for the last study/exam event and update course list accordingly
- event update method now checks for the last study/exam and updates course list accordingly
- as of now, once all course, study, and exam events for a specific course is deleted, this course will be removed from the student's course list
- modifying an existing non-course event into a course event now correctly updates the user's course list

Resolution: Resolved

Workaround: Create or modify an existing an event, set its type to course, and enter the course information for the specific course in question. Delete this event after creation/modification.